### PR TITLE
fix: use optional instead of null

### DIFF
--- a/src/main/java/io/mybatis/provider/defaults/DefaultEntityColumnFactoryChain.java
+++ b/src/main/java/io/mybatis/provider/defaults/DefaultEntityColumnFactoryChain.java
@@ -37,7 +37,7 @@ public class DefaultEntityColumnFactoryChain implements EntityColumnFactory.Chai
     if (index < factories.size()) {
       return factories.get(index).createEntityColumn(entityTable, field, next);
     }
-    return null;
+    return Optional.empty();
   }
 
 }


### PR DESCRIPTION
use Optional.empty() instead of null to avoid npe from DefaultEntityColumnFactoryChain#createEntityColumn

Closes #3